### PR TITLE
Reduce historical data count for improved performance

### DIFF
--- a/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
+++ b/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
@@ -57,7 +57,7 @@ namespace QuantConnect.DataSource.DerivativeUniverseGenerator
         /// </summary>
         protected virtual Resolution[] PriceHistoryResolutions { get; } = new[] { Resolution.Daily };
 
-        private readonly int _historyBarCount = 5;
+        private readonly int _historyBarCount = 1;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DerivativeUniverseGenerator" /> class.


### PR DESCRIPTION
Reduce historical data count for improved performance. One bar is enough for Greeks calculation