### PR TITLE
Allow FOPs universe file generation when missing underlying data

### DIFF
--- a/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
+++ b/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
@@ -158,17 +158,17 @@ namespace QuantConnect.DataSource.DerivativeUniverseGenerator
 
                     if (underlyingSymbol is not null)
                     {
-                    var underlyingEntryGenerated = TryGenerateAndWriteUnderlyingLine(underlyingSymbol, underlyingMarketHoursEntry, writer,
+                        var underlyingEntryGenerated = TryGenerateAndWriteUnderlyingLine(underlyingSymbol, underlyingMarketHoursEntry, writer,
                             out underlyingEntry, out underlyingHistory);
-                    // Underlying not mapped or missing data, so just skip them
-                    if (!underlyingEntryGenerated)
-                    {
-                        Interlocked.Increment(ref underlyingsWithMissingData);
-                        Log.Error($"DerivativeUniverseGenerator.GenerateUniverses(): " +
-                            $"Underlying data missing for {underlyingSymbol} on {_processingDate:yyyy/MM/dd}, universe file will not be generated.");
-                        UpdateEta(ref symbolCounter, totalContracts, start, contractsSymbols.Count);
-                        return;
-                    }
+                        // Underlying not mapped or missing data, so just skip them. Unless FOPs which don't have greeks, don't need the underlying data
+                        if (!underlyingEntryGenerated && _securityType != SecurityType.FutureOption)
+                        {
+                            Interlocked.Increment(ref underlyingsWithMissingData);
+                            Log.Error($"DerivativeUniverseGenerator.GenerateUniverses(): " +
+                                $"Underlying data missing for {underlyingSymbol} on {_processingDate:yyyy/MM/dd}, universe file will not be generated.");
+                            UpdateEta(ref symbolCounter, totalContracts, start, contractsSymbols.Count);
+                            return;
+                        }
                     }
 
                     var derivativeEntries = GenerateDerivativeEntries(canonicalSymbol, contractsSymbols, derivativeMarketHoursEntry,

--- a/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
+++ b/Lean.DataSource.DerivativeUniverseGenerator/DerivativeUniverseGenerator.cs
@@ -161,7 +161,7 @@ namespace QuantConnect.DataSource.DerivativeUniverseGenerator
                         var underlyingEntryGenerated = TryGenerateAndWriteUnderlyingLine(underlyingSymbol, underlyingMarketHoursEntry, writer,
                             out underlyingEntry, out underlyingHistory);
                         // Underlying not mapped or missing data, so just skip them. Unless FOPs which don't have greeks, don't need the underlying data
-                        if (!underlyingEntryGenerated && _securityType != SecurityType.FutureOption)
+                        if (!underlyingEntryGenerated && NeedsUnderlyingData())
                         {
                             Interlocked.Increment(ref underlyingsWithMissingData);
                             Log.Error($"DerivativeUniverseGenerator.GenerateUniverses(): " +
@@ -389,5 +389,12 @@ namespace QuantConnect.DataSource.DerivativeUniverseGenerator
         /// Factory method to create an instance of <see cref="IDerivativeUniverseFileEntry"/> for the given <paramref name="symbol"/>
         /// </summary>
         protected abstract IDerivativeUniverseFileEntry CreateUniverseEntry(Symbol symbol);
+
+        /// <summary>
+        /// Whether the derivative lines generation requires underlying data.
+        /// If true and the underlying entry has no market data, the derivative entries will be skipped.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract bool NeedsUnderlyingData();
     }
 }

--- a/Lean.DataSource.FuturesUniverseGenerator/FuturesUniverseGenerator.cs
+++ b/Lean.DataSource.FuturesUniverseGenerator/FuturesUniverseGenerator.cs
@@ -52,5 +52,10 @@ namespace QuantConnect.DataSource.FuturesUniverseGenerator
             var symbolChainProvider = new FutureChainSymbolProvider(_dataCacheProvider, _processingDate, _securityType, _market, _dataFolderRoot);
             return symbolChainProvider.GetSymbols();
         }
+
+        protected override bool NeedsUnderlyingData()
+        {
+            return false;
+        }
     }
 }

--- a/Lean.DataSource.OptionsUniverseGenerator/OptionUniverseEntry.cs
+++ b/Lean.DataSource.OptionsUniverseGenerator/OptionUniverseEntry.cs
@@ -46,7 +46,7 @@ namespace QuantConnect.DataSource.OptionsUniverseGenerator
         {
             // Options universes contain a line for the underlying: we don't need greeks for it.
             // Future options don't have greeks either.
-            if (HasGreeks(symbol))
+            if (HasGreeks(symbol.SecurityType))
             {
                 var mirrorOptionSymbol = OptionsUniverseGeneratorUtils.GetMirrorOptionSymbol(symbol);
                 _greeksIndicators = new GreeksIndicators(symbol, mirrorOptionSymbol);
@@ -104,9 +104,9 @@ namespace QuantConnect.DataSource.OptionsUniverseGenerator
         /// <summary>
         /// Returns true if the symbol has greeks.
         /// </summary>
-        public static bool HasGreeks(Symbol symbol)
+        public static bool HasGreeks(SecurityType securityType)
         {
-            return symbol.SecurityType.IsOption() && symbol.SecurityType != SecurityType.FutureOption;
+            return securityType.IsOption() && securityType != SecurityType.FutureOption;
         }
     }
 }

--- a/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
+++ b/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
@@ -85,7 +85,7 @@ namespace QuantConnect.DataSource.OptionsUniverseGenerator
         {
             var generatedEntries = base.GenerateDerivativeEntries(canonicalSymbol, symbols, marketHoursEntry, underlyingHistory, underlyingEntry);
 
-            if (!OptionUniverseEntry.HasGreeks(canonicalSymbol))
+            if (!OptionUniverseEntry.HasGreeks(canonicalSymbol.SecurityType))
             {
                 return generatedEntries;
             }

--- a/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
+++ b/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
@@ -61,7 +61,7 @@ namespace QuantConnect.DataSource.OptionsUniverseGenerator
         protected override bool NeedsUnderlyingData()
         {
             // We don't need underlying data for future options, since they don't have greeks, so no need for underlying data for calculation
-            return _securityType != SecurityType.FutureOption;
+            return OptionUniverseEntry.HasGreeks(_securityType);
         }
 
         /// <summary>

--- a/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
+++ b/Lean.DataSource.OptionsUniverseGenerator/OptionsUniverseGenerator.cs
@@ -58,6 +58,12 @@ namespace QuantConnect.DataSource.OptionsUniverseGenerator
             return new OptionUniverseEntry(symbol);
         }
 
+        protected override bool NeedsUnderlyingData()
+        {
+            // We don't need underlying data for future options, since they don't have greeks, so no need for underlying data for calculation
+            return _securityType != SecurityType.FutureOption;
+        }
+
         /// <summary>
         /// Adds a request for the mirror option symbol to the base list of requests.
         /// </summary>


### PR DESCRIPTION
Allow FOPs universe file generation when missing underlying data. It's not required since FOPs don't have greeks